### PR TITLE
[Fix] update pkg

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = postcss.plugin('get-variables', function (callback) {
   return function (root, postcssResult) {
     var variables = {}
 
-    root.eachRule(function (rule) {
+    root.walkRules(function (rule) {
       if (rule.selectors.length === 1 && isCssRoot(rule.selectors[0]) && rule.parent.type === 'root') {
         rule.each(function (declaration) {
           if (declaration.type === 'decl' && declaration.prop) {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "dependencies": {
     "css-variable": "^1.0.1",
     "is-css-root": "^1.0.1",
-    "postcss": "^5.0.14"
+    "postcss": "^6.0.6"
   },
   "devDependencies": {
-    "ava": "^0.9.1",
+    "ava": "^0.20.0",
     "is-present": "1.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -7,12 +7,13 @@ import isPresent from 'is-present'
 import getVariables from '..'
 
 test('postcss-get-variables', t => {
-  t.plan(2)
+  t.plan(3)
 
   postcss()
     .use(getVariables(variables => {
       t.true(isPresent(variables))
       t.true(isPresent(variables['primary-color']))
+      t.true(Object.keys(variables).length === 3)
     }))
     .process(fixture('basic'))
     .catch(error => {

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,6 @@ import postcss from 'postcss'
 import isPresent from 'is-present'
 import getVariables from '..'
 
-
 test('postcss-get-variables', t => {
   t.plan(2)
 
@@ -22,5 +21,5 @@ test('postcss-get-variables', t => {
 })
 
 function fixture (name) {
-  return fs.readFileSync('fixtures/' + name + '.css', 'utf8').toString()
+  return fs.readFileSync(`./test/fixtures/${name}.css`, 'utf8').toString()
 }


### PR DESCRIPTION
I was used this, but it did not work with the latest version.

There was a deprecated method, so I fixed it.

```
Container#eachAtRule is deprecated. Use Container#walkAtRules instead.
```

In addition, I added a test case. Thanks.